### PR TITLE
Update check license action

### DIFF
--- a/actions/docker-build-and-push/action.yaml
+++ b/actions/docker-build-and-push/action.yaml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Download available artifacts # this supports use of artifacts (currently only frontends)
       with:
         path: artifacts/

--- a/actions/docker-build-and-push/action.yaml
+++ b/actions/docker-build-and-push/action.yaml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v3
       name: Download available artifacts # this supports use of artifacts (currently only frontends)
       with:
         path: artifacts/

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -30,6 +30,16 @@ inputs:
       }
       ```
     required: false
+  license-ignore-file:
+    description: |
+      This file allows for ignoring nuget packages.
+      Example:
+      ```json
+      [
+        "Nuget.Name"
+      ]
+      ```
+    required: false
   tool-version:
     default: 3.0.13
     description: The version of the nuget-license tool to use
@@ -50,6 +60,11 @@ runs:
       if: inputs.license-mapping-file
       run: echo "ARGUMENTS=--licenseurl-to-license-mappings ${{ inputs.license-mapping-file }}" | tee -a $GITHUB_ENV
 
+    - name: Add ignore argument
+      shell: bash
+      if: inputs.license-ignore-file
+      run: echo "ARGUMENTS=--ignored-packages ${{ inputs.license-ignore-file }} ${{ env.ARGUMENTS }}" | tee -a $GITHUB_ENV
+
     - name: Auto-correct project argument
       shell: bash
       run: |
@@ -66,4 +81,4 @@ runs:
 
     - name: Run license check
       shell: bash
-      run: ~/.dotnet/tools/nuget-license -i ${{ env.PROJECT }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}
+      run: ~/.dotnet/tools/nuget-license --input ${{ env.PROJECT }} --allowed-license-types ${{ inputs.allowed-licenses-file }} --error-only ${{ env.ARGUMENTS }}

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -4,7 +4,7 @@ description: Verifies only allowed licenses are in use
 
 inputs:
   project-folder:
-    description: The folder containing the project to check.
+    description: The project folder, project file or solution file to check.
     required: true
   allowed-licenses-file:
     description: |
@@ -48,8 +48,22 @@ runs:
     - name: Add mapping argument
       shell: bash
       if: inputs.license-mapping-file
-      run: echo "ARGUMENTS=--licenseurl-to-license-mappings ${{ inputs.license-mapping-file }}" >> $GITHUB_ENV
+      run: echo "ARGUMENTS=--licenseurl-to-license-mappings ${{ inputs.license-mapping-file }}" | tee -a $GITHUB_ENV
+
+    - name: Auto-correct project argument
+      shell: bash
+      run: |
+        if [ -d '${{ inputs.project-folder }}' ]; then
+          file=$(find '${{ inputs.project-folder }}' \( -iname "*.csproj" -o -iname "*.solution" \) | head -n1)
+          if [ -z "$file" ]; then
+            echo "::error::No project was found in '${{ inputs.project-folder }}'."
+            exit 1
+          fi
+          echo "PROJECT=$file" | tee -a $GITHUB_ENV
+        else
+          echo "PROJECT=${{ inputs.project-folder }}" | tee -a $GITHUB_ENV
+        fi
 
     - name: Run license check
       shell: bash
-      run: ~/.dotnet/tools/nuget-license -i ${{ inputs.project-folder }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}
+      run: ~/.dotnet/tools/nuget-license -i ${{ env.PROJECT }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -31,8 +31,8 @@ inputs:
       ```
     required: false
   tool-version:
-    default: 3.0.13
-    description: The version of the nuget-license tool to use
+    default: 2.4.0
+    description: The version of the dotnet-project-licenses tool to use
     required: false
 
 runs:
@@ -40,10 +40,14 @@ runs:
   steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: | 
+          6.0.x
+          8.0.x
 
-    - name: Install nuget-license tool
+    - name: Install license tool
       shell: bash
-      run: dotnet tool install --global nuget-license --version ${{ inputs.tool-version }}
+      run: dotnet tool install --global dotnet-project-licenses --version ${{ inputs.tool-version }}
 
     - name: Add mapping argument
       shell: bash
@@ -52,4 +56,4 @@ runs:
 
     - name: Run license check
       shell: bash
-      run: ~/.dotnet/tools/nuget-license -i ${{ inputs.project-folder }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}
+      run: ~/.dotnet/tools/dotnet-project-licenses -i ${{ inputs.project-folder }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -41,7 +41,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
+        dotnet-version: | 
           6.0.x
           8.0.x
 

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -4,7 +4,7 @@ description: Verifies only allowed licenses are in use
 
 inputs:
   project-folder:
-    description: The project folder, project file or solution file to check.
+    description: The project folder (not recommended, use a specific file), project file or solution file to check.
     required: true
   allowed-licenses-file:
     description: |
@@ -81,4 +81,4 @@ runs:
 
     - name: Run license check
       shell: bash
-      run: ~/.dotnet/tools/nuget-license --input ${{ env.PROJECT }} --allowed-license-types ${{ inputs.allowed-licenses-file }} --error-only ${{ env.ARGUMENTS }}
+      run: ~/.dotnet/tools/nuget-license --input ${{ env.PROJECT }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -31,8 +31,8 @@ inputs:
       ```
     required: false
   tool-version:
-    default: 2.4.0
-    description: The version of the dotnet-project-licenses tool to use
+    default: 3.0.13
+    description: The version of the nuget-license tool to use
     required: false
 
 runs:
@@ -41,9 +41,9 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
 
-    - name: Install license tool
+    - name: Install nuget-license tool
       shell: bash
-      run: dotnet tool install --global dotnet-project-licenses --version ${{ inputs.tool-version }}
+      run: dotnet tool install --global nuget-license --version ${{ inputs.tool-version }}
 
     - name: Add mapping argument
       shell: bash
@@ -52,4 +52,4 @@ runs:
 
     - name: Run license check
       shell: bash
-      run: ~/.dotnet/tools/dotnet-project-licenses -i ${{ inputs.project-folder }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}
+      run: ~/.dotnet/tools/nuget-license -i ${{ inputs.project-folder }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -41,7 +41,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
+        dotnet-version: |
           6.0.x
           8.0.x
 

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -31,8 +31,8 @@ inputs:
       ```
     required: false
   tool-version:
-    default: 2.4.0
-    description: The version of the dotnet-project-licenses tool to use
+    default: 3.0.13
+    description: The version of the nuget-license tool to use
     required: false
 
 runs:
@@ -40,14 +40,10 @@ runs:
   steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: | 
-          6.0.x
-          8.0.x
 
-    - name: Install license tool
+    - name: Install nuget-license tool
       shell: bash
-      run: dotnet tool install --global dotnet-project-licenses --version ${{ inputs.tool-version }}
+      run: dotnet tool install --global nuget-license --version ${{ inputs.tool-version }}
 
     - name: Add mapping argument
       shell: bash
@@ -56,4 +52,4 @@ runs:
 
     - name: Run license check
       shell: bash
-      run: ~/.dotnet/tools/dotnet-project-licenses -i ${{ inputs.project-folder }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}
+      run: ~/.dotnet/tools/nuget-license -i ${{ inputs.project-folder }} --allowed-license-types ${{ inputs.allowed-licenses-file }} ${{ env.ARGUMENTS }}


### PR DESCRIPTION
This action failed during a cron check in energy-origin repo:

`failed workflow run:`

https://github.com/Energinet-DataHub/energy-origin/issues/1558

---

There seems to be a dependency on dotnet version 6 when running the check licenses tool. Dotnet 6 will in 1 months time no longer be LTS, and dotnet 8 will take its place, with dotnet 9 being the STS.

Investigating further I noticed that the check-licenses tool we use is no longer being maintained, and has seemingly been abandoned by the original author. The README mentions that people should migrate to the fork that spun from it. 

---

`Abandoned:` 

https://github.com/tomchavakis/nuget-license?tab=readme-ov-file

`Maintained fork:` 

https://github.com/sensslen/nuget-license