### PR TITLE
update check license action to support dotnet 9

### DIFF
--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -50,9 +50,10 @@ runs:
   steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
-      dotnet-version: |
-        8.0.304
-        9.0.200
+      with:
+        dotnet-version: |
+          8.0.304
+          9.0.200
 
     - name: Install nuget-license tool
       shell: bash

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -52,7 +52,7 @@ runs:
       uses: actions/setup-dotnet@v4
       dotnet-version: |
         8.0.304
-        9.0.x
+        9.0.200
 
     - name: Install nuget-license tool
       shell: bash

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -50,6 +50,9 @@ runs:
   steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
+      dotnet-version: |
+        8.0.304
+        9.0.x
 
     - name: Install nuget-license tool
       shell: bash

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -41,7 +41,7 @@ inputs:
       ```
     required: false
   tool-version:
-    default: 3.0.13
+    default: 3.1.1
     description: The version of the nuget-license tool to use
     required: false
 
@@ -50,10 +50,6 @@ runs:
   steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: |
-          8.0.403
-          9.0.200
 
     - name: Install nuget-license tool
       shell: bash

--- a/actions/dotnet-check-license/action.yaml
+++ b/actions/dotnet-check-license/action.yaml
@@ -52,7 +52,7 @@ runs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          8.0.304
+          8.0.403
           9.0.200
 
     - name: Install nuget-license tool

--- a/actions/dotnet-validate-solution/action.yaml
+++ b/actions/dotnet-validate-solution/action.yaml
@@ -23,7 +23,10 @@ runs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ inputs.dotnet-version }}
+        dotnet-version: |
+          ${{ inputs.dotnet-version }}
+          9.0.200
+
 
     - name: Cache NuGet packages
       uses: actions/cache@v4

--- a/actions/dotnet-validate-solution/action.yaml
+++ b/actions/dotnet-validate-solution/action.yaml
@@ -23,10 +23,7 @@ runs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          ${{ inputs.dotnet-version }}
-          9.0.200
-
+        dotnet-version: ${{ inputs.dotnet-version }}
 
     - name: Cache NuGet packages
       uses: actions/cache@v4


### PR DESCRIPTION
This PR makes sure we reference the newest version of the dotnet-license tool, as only versions above 3.1.0 have support for dotnet 9:

[https://github.com/sensslen/nuget-license/releases/tag/v3.1.0](https://github.com/sensslen/nuget-license/releases/tag/v3.1.0)